### PR TITLE
Fix scheduler; Add config kwargs; Add s1K

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -64,6 +64,15 @@ eval_every: 1024
 # the optimizer to use; should be one of the options listed here: https://pytorch.org/docs/stable/optim.html
 optimizer: AdamW
 
+# the weight decay for the optimizer
+weight_decay: 0.01
+
+# beta1 for AdamW
+beta1: 0.9
+
+# beta2 for AdamW
+beta2: 0.999
+
 # number of linear warmup steps for the learning rate
 warmup_steps: 150
 

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-conda create --name gritkto3 python=3.10.14
-conda activate gritkto3
+conda create --name halos python=3.10.14
+conda activate halos
 
 conda install pip
 pip install packaging ninja

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-conda create --name halos python=3.10.14
-conda activate halos
+conda create --name gritkto3 python=3.10.14
+conda activate gritkto3
 
 conda install pip
 pip install packaging ninja

--- a/train/trainers.py
+++ b/train/trainers.py
@@ -112,7 +112,7 @@ class BasicTrainer(object):
             self.policy,
             self.reference_model,
             self.optimizer,
-            self.scheduler
+            self.scheduler,
         )
 
         if self.reward_model:
@@ -354,10 +354,11 @@ class BasicTrainer(object):
 
                     mean_train_metrics['counters/examples'] = self.example_counter
                     mean_train_metrics['counters/updates'] = self.batch_counter
-                    self.accelerator.print(f'train stats after {self.example_counter} examples: {formatted_dict(mean_train_metrics)}')
+                    mean_train_metrics['lr'] = self.scheduler.get_last_lr()[0]
+                    self.accelerator.print(f'train stats after {self.batch_counter} steps: {formatted_dict(mean_train_metrics)}')
 
                     if self.config.wandb.enabled and self.accelerator.is_main_process:
-                        wandb.log(mean_train_metrics, step=self.example_counter)
+                        wandb.log(mean_train_metrics, step=self.batch_counter)
 
                     last_log = time.time()
                     batch_metrics = defaultdict(list)


### PR DESCRIPTION
Explanation for changes:
- accelerate steps the processor once for each process so we can either turn that off (implemented solution) or increase the num training steps by num processes; If leaving it as is, what happens is that when running on 2 processes like in the below img it will increase the LR again after reaching 0 --- note that if merging this PR the LR scheduling in your current runs will change
<img width="455" alt="Screenshot 2025-03-03 at 2 14 13 PM" src="https://github.com/user-attachments/assets/1f6b5af2-148a-4117-801c-bb708168b5e0" />

With e.g. 16 processes on s1K-1.1 it looks like below 
<img width="1400" alt="Screenshot 2025-03-03 at 2 20 50 PM" src="https://github.com/user-attachments/assets/148b8275-75e7-44da-8bfc-312178cbef1c" />


- Without the * epochs, the scheduler will also reset after each epoch a bit like above imgs
- Current code logs on examples which is a bit confusing in wandb cuz wandb assumes that the x axis is # steps; E.g. with the current code the plot above would actually be 500 steps; with the changes here it is the correct step count; the downside is that if using grad acc it relogs at the same count but maybe that is fine or can add an if condition to just not log during grad acc (only at the end)
- The new config.yaml values are the default ones so default behavior won't change