### PR TITLE
Average instead of sum losses

### DIFF
--- a/train/trainers.py
+++ b/train/trainers.py
@@ -712,7 +712,7 @@ class UnpairedPreferenceTrainer(BasicTrainer):
         if self.reference_model:
             del reference_chosen_logps, reference_rejected_logps
 
-        return losses.sum(), metrics
+        return losses.mean(), metrics
 
 
 class PairedPreferenceTrainer(BasicTrainer):
@@ -802,7 +802,7 @@ class PairedPreferenceTrainer(BasicTrainer):
         if self.reference_model:
             del reference_chosen_logps, reference_rejected_logps
 
-        return losses.sum(), metrics
+        return losses.mean(), metrics
 
 
 class DPOTrainer(PairedPreferenceTrainer):
@@ -1054,7 +1054,7 @@ class KTOTrainer(UnpairedPreferenceTrainer):
         del policy_chosen_logps, policy_rejected_logps, policy_KL_logps, reference_chosen_logps, reference_rejected_logps, reference_KL_logps
         del combined_rewards, combined_statuses, all_rewards, all_statuses, chosen_rewards_idx, rejected_rewards_idx, all_KL
 
-        return losses.sum(), metrics
+        return losses.mean(), metrics
 
 
 class GRPOTrainer(BasicTrainer):
@@ -1149,7 +1149,7 @@ class GRPOTrainer(BasicTrainer):
         
         del policy_logps, reference_logps, scores, prompt_ids, advantages, group_size, KL, weighted_advantage
         
-        return losses.sum(), metrics
+        return losses.mean(), metrics
 
 
 class PPOTrainer(BasicTrainer):


### PR DESCRIPTION
Notes:
- For SFT it is a bit more subtle as it already normalizes by all tokens; leaving it as is for now, may adapt later in a separate PR
- For PPO leaving it as is as I think `masked_mean(torch.max(policy_losses, policy_losses_clipped), batch['masks'])` already averages losses so it may be fine


Here an example how results for GRPO differed for me previously. After this change the gradnorm in the 2nd step for both cases becomes 111.5.
```
BS 16, 1 GPU, GroupSize 8, GradAcc 1
train stats after 1 steps: {'rewards_train/rewards': '0', 'rewards_train/weighted_advant
age': '0', 'rewards_train/KL': '0', 'loss/train': '0', 'grad_norm': '0', 'examples_per_s
econd': '1.9262', 'counters/examples': 16, 'counters/updates': 1, 'counters/lr': '1e-06'
}                                                                                       
train stats after 2 steps: {'rewards_train/rewards': '0.8125', 'rewards_train/weighted_a
dvantage': '0', 'rewards_train/KL': '0', 'loss/train': '0', 'grad_norm': '1784', 'exampl
es_per_second': '36.225', 'counters/examples': 32, 'counters/updates': 2, 'counters/lr':
 '1e-06'}                                                                               
train stats after 3 steps: {'rewards_train/rewards': '0.0625', 'rewards_train/weighted_a
dvantage': '-3.7253e-09', 'rewards_train/KL': '0', 'loss/train': '9.3132e-10', 'grad_nor
m': '2224', 'examples_per_second': '36.128', 'counters/examples': 48, 'counters/updates'
: 3, 'counters/lr': '1e-06'}                                                            
train stats after 4 steps: {'rewards_train/rewards': '0.6875', 'rewards_train/weighted_a
dvantage': '0', 'rewards_train/KL': '0', 'loss/train': '0', 'grad_norm': '1760', 'exampl
es_per_second': '36.781', 'counters/examples': 64, 'counters/updates': 4, 'counters/lr':
 '1e-06'}
train stats after 5 steps: {'rewards_train/rewards': '0.1875', 'rewards_train/weighted_a
dvantage': '0', 'rewards_train/KL': '0', 'loss/train': '0', 'grad_norm': '2336', 'exampl
es_per_second': '35.421', 'counters/examples': 80, 'counters/updates': 5, 'counters/lr':
 '1e-06'}
train stats after 6 steps: {'rewards_train/rewards': '0.5625', 'rewards_train/weighted_a
dvantage': '3.7253e-09', 'rewards_train/KL': '0', 'loss/train': '-9.3132e-10', 'grad_nor
m': '2544', 'examples_per_second': '36.687', 'counters/examples': 96, 'counters/updates'
: 6, 'counters/lr': '1e-06'}
train stats after 7 steps: {'rewards_train/rewards': '0.875', 'rewards_train/weighted_ad
vantage': '0', 'rewards_train/KL': '0', 'loss/train': '0', 'grad_norm': '2176', 'example
s_per_second': '35.915', 'counters/examples': 112, 'counters/updates': 7, 'counters/lr':
 '1e-06'}
train stats after 8 steps: {'rewards_train/rewards': '0.25', 'rewards_train/weighted_adv
antage': '-3.7253e-09', 'rewards_train/KL': '0', 'loss/train': '9.3132e-10', 'grad_norm'
: '2400', 'examples_per_second': '26.457', 'counters/examples': 128, 'counters/updates':
 8, 'counters/lr': '1e-06'}
train stats after 9 steps: {'rewards_train/rewards': '0.5625', 'rewards_train/weighted_a
dvantage': '-3.7253e-09', 'rewards_train/KL': '0', 'loss/train': '9.3132e-10', 'grad_nor
m': '1808', 'examples_per_second': '36.415', 'counters/examples': 144, 'counters/updates
': 9, 'counters/lr': '1e-06'}
train stats after 10 steps: {'rewards_train/rewards': '0.5625', 'rewards_train/weighted_
advantage': '-3.7253e-09', 'rewards_train/KL': '0', 'loss/train': '9.3132e-10', 'grad_no
rm': '2560', 'examples_per_second': '36.678', 'counters/examples': 160, 'counters/update
s': 10, 'counters/lr': '1e-06'}

BS 16, 1 GPU, GroupSize 8, GradAcc 2
train stats after 1 steps: {'rewards_train/rewards': '0', 'rewards_train/weighted_advant
age': '0', 'rewards_train/KL': '0', 'loss/train': '0', 'grad_norm': '0', 'examples_per_s
econd': '2.6115', 'counters/examples': 16, 'counters/updates': 1, 'counters/lr': '1e-06'
}                                                                                       
train stats after 2 steps: {'rewards_train/rewards': '0.8125', 'rewards_train/weighted_a
dvantage': '0', 'rewards_train/KL': '0', 'loss/train': '0', 'grad_norm': '892', 'example
s_per_second': '33.218', 'counters/examples': 32, 'counters/updates': 2, 'counters/lr': 
'1e-06'}                                                                                
train stats after 3 steps: {'rewards_train/rewards': '0.0625', 'rewards_train/weighted_a
dvantage': '-3.7253e-09', 'rewards_train/KL': '0', 'loss/train': '9.3132e-10', 'grad_nor
m': '1112', 'examples_per_second': '32.824', 'counters/examples': 48, 'counters/updates'
: 3, 'counters/lr': '1e-06'}                                                            
train stats after 4 steps: {'rewards_train/rewards': '0.6875', 'rewards_train/weighted_a
dvantage': '0', 'rewards_train/KL': '0', 'loss/train': '0', 'grad_norm': '880', 'example
s_per_second': '33.123', 'counters/examples': 64, 'counters/updates': 4, 'counters/lr': 
'1e-06'}                                                                                
train stats after 5 steps: {'rewards_train/rewards': '0.1875', 'rewards_train/weighted_a
dvantage': '0', 'rewards_train/KL': '0', 'loss/train': '0', 'grad_norm': '1176', 'exampl
es_per_second': '32.581', 'counters/examples': 80, 'counters/updates': 5, 'counters/lr':
 '1e-06'}                                                                               
train stats after 6 steps: {'rewards_train/rewards': '0.5625', 'rewards_train/weighted_a
dvantage': '3.7253e-09', 'rewards_train/KL': '0', 'loss/train': '-9.3132e-10', 'grad_nor
m': '1272', 'examples_per_second': '33.128', 'counters/examples': 96, 'counters/updates'
: 6, 'counters/lr': '1e-06'}
train stats after 7 steps: {'rewards_train/rewards': '0.875', 'rewards_train/weighted_ad
vantage': '0', 'rewards_train/KL': '0', 'loss/train': '0', 'grad_norm': '1088', 'example
s_per_second': '33.033', 'counters/examples': 112, 'counters/updates': 7, 'counters/lr':
 '1e-06'}
train stats after 8 steps: {'rewards_train/rewards': '0.25', 'rewards_train/weighted_adv
antage': '-3.7253e-09', 'rewards_train/KL': '0', 'loss/train': '9.3132e-10', 'grad_norm'
: '1224', 'examples_per_second': '33.275', 'counters/examples': 128, 'counters/updates':
 8, 'counters/lr': '1e-06'}
train stats after 9 steps: {'rewards_train/rewards': '0.5625', 'rewards_train/weighted_a
dvantage': '-3.7253e-09', 'rewards_train/KL': '0', 'loss/train': '9.3132e-10', 'grad_nor
m': '896', 'examples_per_second': '20.769', 'counters/examples': 144, 'counters/updates'
: 9, 'counters/lr': '1e-06'}
train stats after 10 steps: {'rewards_train/rewards': '0.5625', 'rewards_train/weighted_
advantage': '-3.7253e-09', 'rewards_train/KL': '0', 'loss/train': '9.3132e-10', 'grad_no
rm': '1280', 'examples_per_second': '28.464', 'counters/examples': 160, 'counters/update
s': 10, 'counters/lr': '1e-06'}
```